### PR TITLE
Add volcano API endpoints and handler logic

### DIFF
--- a/src/DiscoverCostaRica.Volcano/DiscoverCostaRica.VolcanoService.Api/Extensions/EndpointExtensions.cs
+++ b/src/DiscoverCostaRica.Volcano/DiscoverCostaRica.VolcanoService.Api/Extensions/EndpointExtensions.cs
@@ -1,0 +1,17 @@
+﻿using DiscoverCostaRica.VolcanoService.Api.Handler;
+
+namespace DiscoverCostaRica.VolcanoService.Api.Extensions;
+
+public static class EndpointExtensions
+{
+    public static IEndpointRouteBuilder MapVolcanoEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        var groups = endpoints.MapGroup("api/v1/volcano");
+
+        groups.MapGet("/", VolcanoHandler.GetVolcanos);
+        groups.MapGet($"/Volcano?id={{id}}", VolcanoHandler.GetVolcanoById);
+        groups.MapGet($"/Volcano/Province?id={{id}}", VolcanoHandler.GetVolcanosByProvince);
+
+        return endpoints;
+    }
+}

--- a/src/DiscoverCostaRica.Volcano/DiscoverCostaRica.VolcanoService.Api/GlobalUsings.cs
+++ b/src/DiscoverCostaRica.Volcano/DiscoverCostaRica.VolcanoService.Api/GlobalUsings.cs
@@ -1,0 +1,1 @@
+﻿global using static DiscoverCostaRica.Shared.Utils.SharedExtensions;

--- a/src/DiscoverCostaRica.Volcano/DiscoverCostaRica.VolcanoService.Api/Handler/VolcanoHandler.cs
+++ b/src/DiscoverCostaRica.Volcano/DiscoverCostaRica.VolcanoService.Api/Handler/VolcanoHandler.cs
@@ -1,0 +1,25 @@
+﻿using DiscoverCostaRica.VolcanoService.Application.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DiscoverCostaRica.VolcanoService.Api.Handler;
+
+public static class VolcanoHandler
+{
+    public static async Task<IResult> GetVolcanos([FromServices] IVolcanoService service, CancellationToken cancellationToken)
+    {
+        var result = await service.GetVolcanos(cancellationToken);
+        return result.ToResult();
+    }
+
+    public static async Task<IResult> GetVolcanoById([FromQuery] int id, [FromServices] IVolcanoService service, CancellationToken cancellationToken)
+    {
+        var result = await service.GetVolcanoById(id, cancellationToken);
+        return result.ToResult();
+    }
+
+    public static async Task<IResult> GetVolcanosByProvince([FromQuery] int id, [FromServices] IVolcanoService service, CancellationToken cancellationToken)
+    {
+        var result = await service.GetVolcanosByProvince(id, cancellationToken);
+        return result.ToResult();
+    }
+}


### PR DESCRIPTION
Introduced a global using directive in `GlobalUsings.cs` to simplify access to shared extensions. Added `EndpointExtensions` to define and map volcano-related API routes under `api/v1/volcano`.

Implemented `VolcanoHandler` to handle the logic for:
- Retrieving all volcanoes (`GET /`).
- Retrieving a volcano by ID (`GET /Volcano?id={id}`).
- Retrieving volcanoes by province ID (`GET /Volcano/Province?id={id}`).

These changes improve modularity, maintainability, and scalability.